### PR TITLE
Prevent libredis tag to appear in every single PHP log line after library initialization.

### DIFF
--- a/php/ext/libredis/libredis.c
+++ b/php/ext/libredis/libredis.c
@@ -658,8 +658,8 @@ PHP_MINIT_FUNCTION(libredis)
     Module_set_alloc_free(g_module, free);
     Module_init(g_module);
 
-    openlog("libredis", 0, LOG_LOCAL2);
     syslog(LOG_DEBUG, "libredis module init");
+    closelog();
 
     return SUCCESS;
 }
@@ -699,6 +699,7 @@ PHP_MSHUTDOWN_FUNCTION(libredis)
 
     openlog("libredis", 0, LOG_LOCAL2);
     syslog(LOG_DEBUG, "libredis module shutdown complete, final alloc: %d\n", Module_get_allocated(g_module));
+    closelog();
 
     return SUCCESS;
 }
@@ -711,6 +712,7 @@ PHP_RINIT_FUNCTION(libredis)
 {
     openlog("libredis", 0, LOG_LOCAL2);
     syslog(LOG_DEBUG, "libredis request init");
+    closelog();
 
     return SUCCESS;
 }
@@ -727,6 +729,7 @@ PHP_RSHUTDOWN_FUNCTION(libredis)
 
     openlog("libredis", 0, LOG_LOCAL2);
     syslog(LOG_DEBUG, "libredis request shutdown complete, final alloc: %d, g_batchsz: %d\n", Module_get_allocated(g_module), g_batch.nNumOfElements);
+    closelog();
 
     return SUCCESS;
 }


### PR DESCRIPTION
I've patched source code in order to prevent libredis inserting "libredis" tag in every single line of PHP logs after its initialization (even when the log line has nothing to do with libredis).
Include it to the master repo if it's OK to you.

Regards,
Jordi Clariana.
